### PR TITLE
fixes issue with SYSTEM: Command get_youtube_video_info returned: Error: list index out of range 

### DIFF
--- a/src/autogpt_youtube/youtube_api.py
+++ b/src/autogpt_youtube/youtube_api.py
@@ -154,5 +154,7 @@ def get_youtube_video_info(url: str):
             )
         except KeyError:
             pass
-
-    return results[0]
+    if results[0] == None:
+        return None
+    else:
+        return results[0]


### PR DESCRIPTION
I fixed the issue where the user is getting a invalid range so i changed it to check if the list index is in range, and if it is not then it will return nothing. Here is the issue: SYSTEM: Command get_youtube_video_info returned: Error: list index out of range #9